### PR TITLE
inline buffers in xxHash structures

### DIFF
--- a/xxHash64/xxHash64.go
+++ b/xxHash64/xxHash64.go
@@ -19,15 +19,13 @@ type xxHash struct {
 	v3       uint64
 	v4       uint64
 	totalLen uint64
-	buf      []byte
+	buf      [32]byte
+	bufused  int
 }
 
 // New returns a new Hash64 instance.
 func New(seed uint64) hash.Hash64 {
-	xxh := &xxHash{
-		seed: seed,
-		buf:  make([]byte, 0, 32),
-	}
+	xxh := &xxHash{seed: seed}
 	xxh.Reset()
 	return xxh
 }
@@ -46,7 +44,7 @@ func (xxh *xxHash) Reset() {
 	xxh.v3 = xxh.seed
 	xxh.v4 = xxh.seed - prime64_1
 	xxh.totalLen = 0
-	xxh.buf = xxh.buf[:0]
+	xxh.bufused = 0
 }
 
 // Size returns the number of bytes returned by Sum().
@@ -63,20 +61,22 @@ func (xxh *xxHash) BlockSize() int {
 // It never returns an error.
 func (xxh *xxHash) Write(input []byte) (int, error) {
 	n := len(input)
-	m := len(xxh.buf)
+	m := xxh.bufused
 
 	xxh.totalLen += uint64(n)
 
-	r := 32 - m
+	r := len(xxh.buf) - m
 	if n < r {
-		xxh.buf = append(xxh.buf, input...)
+		copy(xxh.buf[m:], input)
+		xxh.bufused += len(input)
 		return n, nil
 	}
 
 	p := 0
 	if m > 0 {
 		// some data left from previous update
-		xxh.buf = append(xxh.buf, input[:r]...)
+		copy(xxh.buf[xxh.bufused:], input[:r])
+		xxh.bufused += len(input) - r
 
 		// fast rotl(31)
 		p64 := xxh.v1 + (uint64(xxh.buf[p+7])<<56|uint64(xxh.buf[p+6])<<48|uint64(xxh.buf[p+5])<<40|uint64(xxh.buf[p+4])<<32|uint64(xxh.buf[p+3])<<24|uint64(xxh.buf[p+2])<<16|uint64(xxh.buf[p+1])<<8|uint64(xxh.buf[p]))*prime64_2
@@ -92,7 +92,7 @@ func (xxh *xxHash) Write(input []byte) (int, error) {
 		xxh.v4 = (p64<<31 | p64>>33) * prime64_1
 
 		p = r
-		xxh.buf = xxh.buf[:0]
+		xxh.bufused = 0
 	}
 
 	for n := n - 32; p <= n; {
@@ -110,7 +110,8 @@ func (xxh *xxHash) Write(input []byte) (int, error) {
 		p += 8
 	}
 
-	xxh.buf = append(xxh.buf, input[p:]...)
+	copy(xxh.buf[xxh.bufused:], input[p:])
+	xxh.bufused += len(input) - p
 
 	return n, nil
 }
@@ -144,7 +145,7 @@ func (xxh *xxHash) Sum64() uint64 {
 	}
 
 	p := 0
-	n := len(xxh.buf)
+	n := xxh.bufused
 	for n := n - 8; p <= n; p += 8 {
 		p64 := (uint64(xxh.buf[p+7])<<56 | uint64(xxh.buf[p+6])<<48 | uint64(xxh.buf[p+5])<<40 | uint64(xxh.buf[p+4])<<32 | uint64(xxh.buf[p+3])<<24 | uint64(xxh.buf[p+2])<<16 | uint64(xxh.buf[p+1])<<8 | uint64(xxh.buf[p])) * prime64_2
 		h64 ^= ((p64 << 31) | (p64 >> 33)) * prime64_1


### PR DESCRIPTION
This way, `New` requires only one allocation instead of two.