### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 
 go:
-  - 1.4
-  - 1.5
+  - 1.13
+  - 1.14
+  - 1.15
 
 script: 
  - go test -cpu=2 github.com/pierrec/xxHash/xxHash32


### PR DESCRIPTION
Adding power support & updating the go versions to >=1.13 as the lower versions are not supported.,

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/xxHash

Please let me know if you need any further details

Thank You !!